### PR TITLE
added server to rpcserver

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4379,7 +4379,7 @@ type rpcserverConfig struct {
 }
 
 // newRPCServer returns a new instance of the rpcServer struct.
-func newRPCServer(config *rpcserverConfig) (*rpcServer, error) {
+func newRPCServer(config *rpcserverConfig, s *server) (*rpcServer, error) {
 	rpc := rpcServer{
 		cfg:                    *config,
 		statusLines:            make(map[int]string),
@@ -4400,6 +4400,7 @@ func newRPCServer(config *rpcserverConfig) (*rpcServer, error) {
 	}
 	rpc.ntfnMgr = newWsNotificationManager(&rpc)
 	rpc.cfg.Chain.Subscribe(rpc.handleBlockchainNotification)
+	rcp.server = s
 
 	return &rpc, nil
 }

--- a/server.go
+++ b/server.go
@@ -2995,7 +2995,7 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 			AddrIndex:    s.addrIndex,
 			CfIndex:      s.cfIndex,
 			FeeEstimator: s.feeEstimator,
-		})
+		}, &s)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This allows us to use https://github.com/btcsuite/btcd/pull/1441 and avoid null pointer references since any calls w/ `s.server` would have a fatal error